### PR TITLE
Improve app startup resiliency and surface initialization errors

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,19 +23,97 @@ void main() async {
   GoRouter.optionURLReflectsImperativeAPIs = true;
   usePathUrlStrategy();
 
-  await initFirebase();
+  runApp(const AppBootstrap());
+}
 
-  await SupaFlow.initialize();
+class AppBootstrap extends StatefulWidget {
+  const AppBootstrap({super.key});
 
-  await FlutterFlowTheme.initialize();
+  @override
+  State<AppBootstrap> createState() => _AppBootstrapState();
+}
 
-  final appState = FFAppState(); // Initialize FFAppState
-  await appState.initializePersistedState();
+class _AppBootstrapState extends State<AppBootstrap> {
+  late final Future<FFAppState> _initialization;
 
-  runApp(ChangeNotifierProvider(
-    create: (context) => appState,
-    child: MyApp(),
-  ));
+  @override
+  void initState() {
+    super.initState();
+    _initialization = _initializeDependencies();
+  }
+
+  Future<FFAppState> _initializeDependencies() async {
+    await initFirebase();
+    await SupaFlow.initialize();
+    await FlutterFlowTheme.initialize();
+
+    final appState = FFAppState();
+    await appState.initializePersistedState();
+    return appState;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<FFAppState>(
+      future: _initialization,
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return MaterialApp(
+            debugShowCheckedModeBanner: false,
+            home: _StartupErrorScreen(error: snapshot.error),
+          );
+        }
+
+        if (!snapshot.hasData) {
+          return const MaterialApp(
+            debugShowCheckedModeBanner: false,
+            home: Scaffold(
+              body: Center(child: CircularProgressIndicator()),
+            ),
+          );
+        }
+
+        return ChangeNotifierProvider(
+          create: (context) => snapshot.data!,
+          child: MyApp(),
+        );
+      },
+    );
+  }
+}
+
+class _StartupErrorScreen extends StatelessWidget {
+  const _StartupErrorScreen({required this.error});
+
+  final Object? error;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.error_outline, color: Colors.red, size: 56.0),
+              const SizedBox(height: 16.0),
+              const Text(
+                'App failed to initialize',
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 22.0, fontWeight: FontWeight.w600),
+              ),
+              const SizedBox(height: 8.0),
+              Text(
+                error?.toString() ?? 'Unknown error',
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class MyApp extends StatefulWidget {


### PR DESCRIPTION
### Motivation
- Replace fragile eager async initialization in `main()` with a controlled bootstrap so initialization failures are visible instead of causing a blank/crashed app. 
- Make startup flow explicit so Firebase, Supabase, theme state, and persisted app state are initialized in a single place for easier debugging. 

### Description
- Replaced the direct initialization in `main()` with a `AppBootstrap` widget that performs async setup via `_initializeDependencies`. 
- Added `FutureBuilder`-backed loading UI that shows a `CircularProgressIndicator` while initialization runs. 
- Added a `_StartupErrorScreen` that displays the initialization exception message instead of failing silently. 
- All changes are contained in `lib/main.dart` (new `AppBootstrap`, `_initializeDependencies`, and `_StartupErrorScreen`). 

### Testing
- Ran `git diff --check` which succeeded with no whitespace or diff-check errors. 
- Attempted `flutter --version` and `dart --version` but both commands were unavailable in the environment (`bash: command not found`). 
- Ran a Playwright navigation check against `http://127.0.0.1:3000` which failed because no local app server was responding (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993dd438bd48333a09e46956f4b1ea0)